### PR TITLE
Phase 1: Get Bill Ranges from ILGA

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "windy-civi",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}

--- a/scraper/package.json
+++ b/scraper/package.json
@@ -4,6 +4,7 @@
   "scripts": {
     "get-cache": "npx ts-node cache-grabber/run",
     "scrape": "npx ts-node scrapers/run",
+    "scrape-il-test": "npx ts-node scrapers/localities/illinois.ilga",
     "gpt": "npx ts-node gpt-summaries/run",
     "wiki": "npx ts-node wiki-summaries/run",
     "postinstall": "tsc api/*.ts --outDir dist_api --declaration --declarationMap --sourceMap"

--- a/scraper/scrapers/localities/illinois.ilga.ts
+++ b/scraper/scrapers/localities/illinois.ilga.ts
@@ -1,0 +1,81 @@
+import axios from 'axios';
+import * as cheerio from 'cheerio';
+import { CiviLegislationData } from '../../api/types'
+
+// A range of bills and corresponding URL for more information
+interface BillRange {
+  url: string;
+  range: string;
+}
+
+const getFilteredBillRanges = ($: cheerio.CheerioAPI, anchorElements: cheerio.Cheerio<cheerio.Element>,filterText: string): {href: string, text: string}[] => {
+  const $filteredAnchors = anchorElements.filter((_, element) => {
+    const href = $(element).attr('href') || '';
+    // Example filter: only include hrefs that contain '/legislation/'
+    return href.includes(filterText);
+    });
+
+    // Extract relevant information from filtered anchors
+    const filteredBillRanges = $filteredAnchors.map((_, element) => {
+      const $element = $(element);
+      return {
+        href: $element.attr('href') || '',
+        text: $element.text().trim(),
+      };
+    }).get(); // Use `.get()` to convert Cheerio object to a plain array}
+
+    return filteredBillRanges;
+}
+
+const getBillRanges = async (): Promise<BillRange[]> => {
+  try {
+    // Fetch the webpage content
+    const { data } = await axios.get('https://www.ilga.gov/legislation/');
+
+    // Load the webpage content into cheerio
+    const $ = cheerio.load(data);
+
+    // Array to hold the bill ranges
+    const billRanges: BillRange[] = [];
+
+    // Select all anchor elements
+    const $anchors = $('a');
+
+    // Get the Senate Bill Ranges
+    const senateBillRanges = getFilteredBillRanges($, $anchors, "SB&GA");
+
+    // Get the House Bill Ranges
+    const houseBillRanges = getFilteredBillRanges($, $anchors, "HB&GA");
+
+    const allBillRangeObjects = [...senateBillRanges, ...houseBillRanges]
+
+    allBillRangeObjects.forEach(range => {
+      billRanges.push({
+        url: range.href,
+        range: range.text
+      });
+    });
+    return billRanges;
+  }
+  catch(error) {
+    console.error('Error scraping bills:', error);
+    return [];
+  }
+}
+
+// Function to scrape the bills
+export const scrapeILBills = async (): Promise<BillRange[]> => {
+  //get senate and house bill ranges
+  let billRanges: BillRange[] = []
+  getBillRanges().then(ranges => {
+    console.log('Bill Ranges:', ranges);
+    billRanges = ranges;
+  }).catch(console.error);
+
+  //TODO: For each range, get the list of bills
+
+  //TODO: For each bill, collect the CiviLegislationData. Update this method to return that array.
+  return billRanges;
+}
+
+scrapeILBills();


### PR DESCRIPTION
This PR introduces a new locality scraper that scrapes the Illinois General Assembly Bills homepage and retrieves the bill ranges for house or senate bills, structured as the range text and associated url. To demo, change directory into the `scraper` folder and run `npm run scrape-il-test` - you should see ~100 bill ranges logged to the console.

Next steps:
* Iterate through the range URLs and repeat this process with the resulting bills
* Iterate through the bill URLs and scrape as needed to create structured CiviLegislationData
* Write this structured data to the `dist_` folder
* Create a scraper for federal legislation based off of the Library of Congress API
* Update the `npm run scrape` command to reference the new scrapers