### PR TITLE
Dockerized workflow steps for scrape, builder

### DIFF
--- a/scraper_next/blockchain_builder/.dockerignore
+++ b/scraper_next/blockchain_builder/.dockerignore
@@ -1,3 +1,5 @@
 Dockerfile
 .dockerignore
-sample_open_civic_data_blockchain/
+sample_input_files/
+input/
+output/

--- a/scraper_next/blockchain_builder/.dockerignore
+++ b/scraper_next/blockchain_builder/.dockerignore
@@ -1,0 +1,3 @@
+Dockerfile
+.dockerignore
+sample_open_civic_data_blockchain/

--- a/scraper_next/blockchain_builder/.gitignore
+++ b/scraper_next/blockchain_builder/.gitignore
@@ -1,0 +1,1 @@
+sample_open_civic_data_blockchain/

--- a/scraper_next/blockchain_builder/Dockerfile
+++ b/scraper_next/blockchain_builder/Dockerfile
@@ -1,0 +1,10 @@
+FROM python:3.13-alpine
+
+WORKDIR /app
+
+COPY Pipfile Pipfile.lock ./
+
+RUN pip install pipenv && \
+  pipenv install --deploy --ignore-pipfile
+
+COPY . .

--- a/scraper_next/blockchain_builder/Pipfile
+++ b/scraper_next/blockchain_builder/Pipfile
@@ -1,0 +1,14 @@
+[[source]]
+url = "https://pypi.org/simple"
+verify_ssl = true
+name = "pypi"
+
+[pipenv]
+sort_pipfile = true
+
+[packages]
+
+[dev-packages]
+
+[requires]
+python_version = "3.13"

--- a/scraper_next/blockchain_builder/Pipfile.lock
+++ b/scraper_next/blockchain_builder/Pipfile.lock
@@ -1,0 +1,20 @@
+{
+    "_meta": {
+        "hash": {
+            "sha256": "494d5b4f482f0ef471f49afe28f00ec1a2ff75da2ce65060d8cabaeb3da2f100"
+        },
+        "pipfile-spec": 6,
+        "requires": {
+            "python_version": "3.13"
+        },
+        "sources": [
+            {
+                "name": "pypi",
+                "url": "https://pypi.org/simple",
+                "verify_ssl": true
+            }
+        ]
+    },
+    "default": {},
+    "develop": {}
+}

--- a/scraper_next/blockchain_builder/README.md
+++ b/scraper_next/blockchain_builder/README.md
@@ -26,13 +26,16 @@ This Python script processes civic JSON files (bills, vote events, and others) a
 
 ## How to Run
 
-- Update `INPUT_FOLDER` and `OUTPUT_FOLDER` variables in `main.py` as needed.
-- When running the script, it will automatically ask if you want to delete the existing `OUTPUT_FOLDER` before starting.
+- Set environment variables `BUILDER_INPUT_FOLDER` and `BUILDER_OUTPUT_FOLDER` as needed.
+  - Defaults: `./input` & `./output`.
+- When running the script, it will automatically ask if you want to delete the existing `BUILDER_OUTPUT_FOLDER` before starting.
 - If you confirm, it will clear the output for a clean run.
-- A `sample_input_files/` folder is included for testing the script with a small dataset.cd
+- A `sample_input_files/` folder is included for testing the script with a small dataset.
+
+Run with sample input, using the default output directory:
 
 ```bash
-python main.py
+BUILDER_INPUT_FOLDER=sample_input_files python main.py
 ```
 
 ---

--- a/scraper_next/blockchain_builder/main.py
+++ b/scraper_next/blockchain_builder/main.py
@@ -1,15 +1,13 @@
 import os
 import json
 import shutil
+import sys
 from pathlib import Path
 from datetime import datetime
 
 # -------------------------
 # CONFIGURATION
 # -------------------------
-INPUT_FOLDER = "sample_input_files"
-OUTPUT_FOLDER = "sample_open_civic_data_blockchain"
-
 SESSION_MAPPING = {
     "104th": "2023-2024",
     "103rd": "2021-2022",
@@ -153,7 +151,16 @@ def load_json_files(input_folder):
 
 
 def clear_output_folder(output_folder):
-    if os.path.exists(output_folder):
+
+    if os.path.exists(output_folder) and not os.path.isdir(output_folder):
+        print(f"🛑 Aborting program, '{output_folder}' is not a folder.")
+        sys.exit(1)
+
+    if os.listdir(output_folder):
+        if not sys.stdin.isatty():
+            print("🛑 Aborting program, output folder not empty.")
+            sys.exit(1)
+
         confirm = (
             input(
                 f"⚠️ This will delete everything in {output_folder}. Are you sure? (yes/no): "
@@ -189,9 +196,11 @@ def process_and_save(data, output_folder):
 
 
 def main():
-    clear_output_folder(OUTPUT_FOLDER)
-    all_json_files = load_json_files(INPUT_FOLDER)
-    process_and_save(all_json_files, OUTPUT_FOLDER)
+    input_folder = os.getenv("BUILDER_INPUT_FOLDER", "./input")
+    output_folder = os.getenv("BUILDER_OUTPUT_FOLDER", "./output")
+    clear_output_folder(output_folder)
+    all_json_files = load_json_files(input_folder)
+    process_and_save(all_json_files, output_folder)
 
 
 if __name__ == "__main__":

--- a/workflow/README.md
+++ b/workflow/README.md
@@ -1,0 +1,57 @@
+# Docker Based Workflow
+
+Workflow steps overview:
+
+1. `openstate_scrape` - scrape data using openstates scrapers
+2. `builder` - process resulting data with windy civi transform
+
+## Create necessary docker images
+
+### openstates scraper
+
+The openstates.org project provides a Docker file that can be used. They
+currently publish docker images (via [GH actions][gha]) to dockerhub. See
+https://hub.docker.com/r/openstates/scrapers
+
+NOTE: Only images built for `amd64` platform are published to dockerhub. For
+`arm64` you will need to build a compatible image.
+
+```sh
+% docker build . -t scrapers
+
+# Run --help on the default entrypoint `openstates`
+% docker run scrapers --help
+```
+
+[gha]: https://github.com/openstates/openstates-scrapers/blob/main/.github/workflows/docker.yml
+
+### windy-civi builder
+
+A simple [Dockerfile] is included with the builder script. Build the image:
+
+```sh
+% docker build . -t builder
+```
+
+[Dockerfile]: ../scraper_next/blockchain_builder/Dockerfile
+
+## Run Workflow Steps
+
+### Run step: `openstate_scrape`
+
+```
+% docker run \
+    -v "$(pwd)/working/_data":/opt/openstates/openstates/_data \
+    -v "$(pwd)/working/_cache":/opt/openstates/openstates/_cache \
+    scrapers il bills --scrape --fastmode
+```
+
+### Run step: `builder`
+
+```
+% docker run \
+    -v "$(pwd)/working":/data \
+    -e BUILDER_INPUT_FOLDER=/data/_data/il \
+    -e BUILDER_OUTPUT_FOLDER=/data/output \
+    builder python main.py
+```


### PR DESCRIPTION
This builds on the work of #60 and explores running workflow steps as docker containers.

1. Use existing openstates scrapers docker image - openstates provides a docker image, but only releases for amd64 from what I can tell. For arm64, I needed to build the image locally. Other than that, just required some volume mounts in the run to get it to put the scrape results in a directory outside of the image on my local machine. No changes for this repo, other than including some documentation.

2. Dockerize the builder tool - Add some small modifications to the builder script to allow setting directory configuration via env vars, and then packaged it all up in it's own docker image. This can then be used with the same mounted directories as Part 1 to process the scraped data into the builder layout.

Draft for now to just get some feedback on direction, and ensure the setup works for other environments.